### PR TITLE
refactor(plugins):  use 'useNuxtApp'

### DIFF
--- a/plugins/naive-ui.ts
+++ b/plugins/naive-ui.ts
@@ -1,15 +1,15 @@
 import { setup } from '@css-render/vue3-ssr'
-import { defineNuxtPlugin } from '#app'
 
-export default defineNuxtPlugin((nuxtApp) => {
+export default defineNuxtPlugin(() => {
+  const nuxtApp = useNuxtApp()
   if (process.server) {
     const { collect } = setup(nuxtApp.vueApp)
     const originalRenderMeta = nuxtApp.ssrContext?.renderMeta
-    nuxtApp.ssrContext = nuxtApp.ssrContext || {}
-    nuxtApp.ssrContext.renderMeta = () => {
+    nuxtApp.ssrContext = nuxtApp.ssrContext
+    nuxtApp.ssrContext!.renderMeta = () => {
       if (!originalRenderMeta) {
         return {
-          headTags: collect()
+          headTags: collect(),
         }
       }
       const originalMeta = originalRenderMeta()
@@ -17,13 +17,13 @@ export default defineNuxtPlugin((nuxtApp) => {
         return originalMeta.then((resolvedOriginalMeta) => {
           return {
             ...resolvedOriginalMeta,
-            headTags: resolvedOriginalMeta['headTags'] + collect()
+            headTags: resolvedOriginalMeta['headTags'] + collect(),
           }
         })
       } else {
         return {
           ...originalMeta,
-          headTags: originalMeta['headTags'] + collect()
+          headTags: originalMeta['headTags'] + collect(),
         }
       }
     }


### PR DESCRIPTION
1. `nuxtApp` 更换 为 `useNuxtApp` 可参考：https://nuxt.com/docs/guide/directory-structure/plugins#using-composables-within-plugins

2. 解决 `ssrContext` 类型报错问题